### PR TITLE
chore: add undefined as promise return type in RouteBeforeEnterResult

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -123,7 +123,7 @@ Example of all these handlers:
 ```js
 {
   $: '/foo/',
-  beforeEnter: ({oldPath, newPath, params}) => void | Promise<{ redirect: string, replace?: boolean }>,
+  beforeEnter: ({oldPath, newPath, params}) => void | Promise<{ redirect: string, replace?: boolean } | undefined>,
   enter: ({oldPath, newPath, params}) => void,
   beforeLeave: ({oldPath, newPath}): void | false | Promise<{ redirect: string, replace?: boolean }>,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export interface RouteEnterEvent extends RouteChangeEvent {
   params: MatchResultParams
 }
 
-export type RouteBeforeEnterResult = void | null | undefined | { redirect: string, replace?: boolean } | Promise<{ redirect: string, replace?: boolean }>;
+export type RouteBeforeEnterResult = void | null | undefined | { redirect: string, replace?: boolean } | Promise<{ redirect: string, replace?: boolean } | undefined>;
 export type RouteEnterResult = void;
 /*
  * false means you want to prevent leave


### PR DESCRIPTION
Add `Promise<undefined | ...>` as return type in an async `beforeEnter` method. 